### PR TITLE
Add web-security option

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,10 @@ function casper(options) {
     if (options.nocolors) {
         args.push('--no-colors');
     }
+    
+    if (options.websecurity) {
+        args.push('--web-security=' + options.websecurity);
+    }
 
     var cmd = (typeof options.command === 'undefined') ? 'test' : options.command;
 


### PR DESCRIPTION
Phantom 2.1.1 on MacOs Sierra has problem with ajax requests. It is possible to remove them with --web-security=false option.
See http://stackoverflow.com/questions/15913170/phantom-js-synchronous-ajax-request-network-err-xmlhttprequest-exception-101